### PR TITLE
Add feign exception handler, deal with 404 page 

### DIFF
--- a/MangoLee-CMS-Gateway/src/main/resources/application.yml
+++ b/MangoLee-CMS-Gateway/src/main/resources/application.yml
@@ -14,3 +14,7 @@ spring:
           uri: lb://nacos-consumer
           predicates:
             - Path=/consumer/**
+        - id: RedisConsumer
+          uri: lb://redis-consumer
+          predicates:
+            - Path=/consumer/**

--- a/MangoLee-CMS-common/pom.xml
+++ b/MangoLee-CMS-common/pom.xml
@@ -23,5 +23,9 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/MangoLee-CMS-common/src/main/java/org/mangolee/config/FeignClientErrorDecoder.java
+++ b/MangoLee-CMS-common/src/main/java/org/mangolee/config/FeignClientErrorDecoder.java
@@ -1,0 +1,24 @@
+package org.mangolee.config;
+
+import feign.Response;
+import feign.Util;
+import feign.codec.ErrorDecoder;
+import org.mangolee.exception.MyFeignException;
+import org.mangolee.utils.Result;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+public class FeignClientErrorDecoder implements ErrorDecoder {
+    @Override
+    public Exception decode(String s, Response response) {
+        try{
+            String errorContent = Util.toString(response.body().asReader());
+        } catch (IOException ioException) {
+            ioException.printStackTrace();
+            return new RuntimeException(ioException);
+        }
+        return new MyFeignException(Result.INTERNAL_ERROR);
+    }
+}

--- a/redis-service-consumer/src/main/resources/application.yaml
+++ b/redis-service-consumer/src/main/resources/application.yaml
@@ -6,6 +6,8 @@ spring:
     name: redis-consumer
   mvc:
     throw-exception-if-no-handler-found: true
+  resources:
+    add-mappings: false
   cloud:
     nacos:
       discovery:

--- a/redis-service-consumer/src/main/resources/application.yaml
+++ b/redis-service-consumer/src/main/resources/application.yaml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: redis-consumer
+  mvc:
+    throw-exception-if-no-handler-found: true
   cloud:
     nacos:
       discovery:

--- a/redis-service-providers/src/main/resources/application.yaml
+++ b/redis-service-providers/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
   redis:
     database: 0
     port: 6379

--- a/redis-service-providers/src/main/resources/application.yaml
+++ b/redis-service-providers/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 spring:
   mvc:
     throw-exception-if-no-handler-found: true
+  resources:
+    add-mappings: false
   redis:
     database: 0
     port: 6379


### PR DESCRIPTION
Add feign exception decoder to ensure that when exception happens with feign, it throws our MyFeignException instance.

And settings to yml config file of micro-sevices so that when the request path is incorrect we do not get a HTML page, but json reply.